### PR TITLE
Fix: Use the latest `wasm_exec.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 wasm-demo.wasm
+lib/wasm_exec.js

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ PKG := github.com/guggero/wasm-demo
 LDFLAGS := -s -w -buildid=
 
 wasm:
+	# This copies the latest version of `wasm_exec.js`.
+	cp $(shell go env GOROOT)/misc/wasm/wasm_exec.js ./lib/wasm_exec.js
+	
 	# The appengine build tag is needed because of the jessevdk/go-flags library
 	# that has some OS specific terminal code that doesn't compile to WASM.
 	GOOS=js GOARCH=wasm go build -trimpath -ldflags="$(LDFLAGS)" -tags="appengine" -v -o wasm-demo.wasm .


### PR DESCRIPTION
Copies `$(go env GOROOT)/misc/wasm/wasm_exec.js` to `./lib/wasm_exec.js`. Closes #1.